### PR TITLE
Disable favorite removal if path is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,6 @@ const favorites: JupyterFrontEndPlugin<void> = {
         const favorite = args.favorite as IFavorites.Favorite;
         const path = favorite.path === '' ? '/' : favorite.path;
         await commands.execute('filebrowser:open-path', { path });
-        // favoritesManager.removeFavoriteIfInvalid(favorite);
       },
       label: (args) => {
         const favorite = args.favorite as IFavorites.Favorite;

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ const favorites: JupyterFrontEndPlugin<void> = {
         const favorite = args.favorite as IFavorites.Favorite;
         const path = favorite.path === '' ? '/' : favorite.path;
         await commands.execute('filebrowser:open-path', { path });
-        favoritesManager.removeFavoriteIfInvalid(favorite);
+        // favoritesManager.removeFavoriteIfInvalid(favorite);
       },
       label: (args) => {
         const favorite = args.favorite as IFavorites.Favorite;


### PR DESCRIPTION
I wasn't able to create an issue, so I'll describe it here in the PR.

The current behavior of favorites is to remove a favorite link if the path can't be reached.  I think this was meant to be a way to clean dead links, however, it has an unintended effect that if a given path is temporarily unavailable, clicking on the link will remove it.

This PR is simply to comment out the line responsible for removing the link automatically.