### PR TITLE
Initialise _showWidget in FavoritesManager

### DIFF
--- a/.github/workflows/binder-on-pr.yaml
+++ b/.github/workflows/binder-on-pr.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: comment on PR with Binder link
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
           var PR_HEAD_REF = process.env.PR_HEAD_REF;
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,25 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-       node-version: '12.x'
+       node-version: '16'
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
-        architecture: 'x64'
-    
+        python-version: '3.10'
     
     - name: Setup pip cache
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: pip-3.7-${{ hashFiles('package.json') }}
+        key: pip-3.10-${{ hashFiles('package.json') }}
         restore-keys: |
-          pip-3.7-
+          pip-3.10-
           pip-
 
     - name: Get yarn cache directory path
@@ -66,7 +64,7 @@ jobs:
         pip uninstall -y myextension jupyterlab
         rm -rf myextension
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: myextension-sdist
         path: myextension.tar.gz
@@ -77,13 +75,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
-          architecture: 'x64'
-      - uses: actions/download-artifact@v2
+          python-version: '3.10'
+      - uses: actions/download-artifact@v3
         with:
           name: myextension-sdist
       - name: Install and Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '16'
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -17,6 +17,7 @@ export class FavoritesManager {
     settings: ISettingRegistry,
     contents: ContentsManager
   ) {
+    this._showWidget = true;
     this._serverRoot = serverRoot;
     this._commandRegistry = commands;
     this._settingsRegistry = settings;


### PR DESCRIPTION
`this._showWidget` can be undefined when the plugin is initially loading. Which causes `isVisible` to return undefined. Which in turn  can cause the widget to never render because React 17 and below will error if `undefined` is returned in the render function. Specifically, this part of the will cause an error if `isVisible` is undefined.
```
{(manager: FavoritesManager, isVisible: boolean) =>
                isVisible && (
                  <>
                    <div className={FAVORITE_HEADER_CLASS}>Favorites</div>
                    <div className={FAVORITE_CONTAINER_CLASS}>
                      {visibleFavorites.map((f) => (
                        <FavoriteComponent
                          key={`favorites-item-${f.path}`}
                          favorite={f}
                          handleClick={manager.handleClick.bind(manager)}
                        />
                      ))}
                    </div>
                    <div className={FILEBROWSER_HEADER_CLASS}>File Browser</div>
                  </>
                )
              }
 ```

I think this has always been a race condition but was very rare. However, since Jupyterlab `v4.0.0a27` I have found that this issue happens consistently and the Favorites never renders widget.