### PR TITLE
Allow to omit the `root` attribute in settings

### DIFF
--- a/schema/favorites.json
+++ b/schema/favorites.json
@@ -22,10 +22,11 @@
           "type": "string"
         },
         "root": {
-          "type": "string"
+          "type": "string",
+          "description": "Root path used for filtering out favourites from instances of JupyterLab launched in a different root directory. If not given the favourite will be shown if the associated file exists."
         }
       },
-      "required": ["root", "path"],
+      "required": ["path"],
       "type": "object"
     }
   },

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -4,7 +4,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { CommandRegistry } from '@lumino/commands';
 import { Contents } from '@jupyterlab/services';
 import { IFavorites, SettingIDs, CommandIDs } from './token';
-import { getName } from './utils';
+import { getName, Optional } from './utils';
 
 export class FavoritesManager {
   favoritesMenu: Menu;
@@ -188,11 +188,17 @@ export class FavoritesManager {
   }
 
   private async loadFavorites() {
-    const favorites = await this._settingsRegistry.get(
+    const setting = await this._settingsRegistry.get(
       SettingIDs.favorites,
       'favorites'
     );
-    this.favorites = (favorites.composite ?? []) as IFavorites.Favorite[];
+    const favorites = (setting.composite ?? []) as Optional<
+      IFavorites.Favorite,
+      'root'
+    >[];
+    this.favorites = favorites.map(favorite => {
+      return { ...favorite, root: favorite.root ?? this.serverRoot };
+    });
   }
 
   private async loadShowWidget() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,3 +22,5 @@ export function getPinnerActionDescription(showRemove: boolean): string {
 export function mergePaths(root: string, path: string): string {
   return PathExt.join(root, path);
 }
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/ui-tests/tests/jupyterlab_favorites.spec.ts
+++ b/ui-tests/tests/jupyterlab_favorites.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
     .getByRole('tab', { name: 'untitled.txt' })
     .waitFor();
   await page.activity.closeAll();
-  await page.getByRole('button', { name: 'New Folder' }).click();
+  await page.getByTitle('New Folder').click();
   await page.locator('.jp-DirListing-editor').press('Escape');
 });
 


### PR DESCRIPTION
Allow to omit the `root` attribute in settings and populate it when loading settings from current root.

Closes #25.