### PR TITLE
Fix breadcrumb icon on preferred directory load

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,6 +132,7 @@ const favorites: JupyterFrontEndPlugin<IFavorites> = {
             return;
           }
           filebrowser.model.pathChanged.disconnect(initializeBreadcrumbsIcon);
+          filebrowser.model.refreshed.disconnect(initializeBreadcrumbsIcon);
           const favoriteIcon = ReactWidget.create(
             <UseSignal
               signal={filebrowser.model.refreshed}
@@ -166,6 +167,7 @@ const favorites: JupyterFrontEndPlugin<IFavorites> = {
         };
 
         filebrowser.model.pathChanged.connect(initializeBreadcrumbsIcon);
+        filebrowser.model.refreshed.connect(initializeBreadcrumbsIcon);
         initializeBreadcrumbsIcon();
       }
     }


### PR DESCRIPTION
Follow up for #49, ref https://github.com/jupyterlab-contrib/jupyterlab-favorites/issues/48#issuecomment-4845613313 closes #48 

Fixes the breadcrumb favorite icon initialization so it retries when the file browser model refreshes, covering first-load cases where the breadcrumb node was not ready yet. This ensures the favorite icon appears correctly when JupyterLab starts in a preferred directory.


tested locally using `--ServerApp.preferred_dir=my_home` and the icon appears.